### PR TITLE
Add metric detail screens

### DIFF
--- a/crm_retail_app/lib/screens/metric_detail_screen.dart
+++ b/crm_retail_app/lib/screens/metric_detail_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'tabs/home_tab.dart';
+
+class MetricDetailScreen extends StatelessWidget {
+  final SummaryMetric metric;
+
+  const MetricDetailScreen({super.key, required this.metric});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final details = _metricDetails[metric.title] ?? <String>[];
+
+    return Scaffold(
+      appBar: AppBar(title: Text(metric.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: metric.color.withOpacity(0.1),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(metric.icon, size: 32, color: metric.color),
+                ),
+                const SizedBox(width: 16),
+                Text(
+                  metric.value,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            ...details.map(
+              (d) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Text(d, style: theme.textTheme.bodyLarge),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static const Map<String, List<String>> _metricDetails = {
+    'Total Revenue': [
+      'Revenue YTD: €98,400',
+      'Avg daily revenue: €1,200',
+    ],
+    'Transactions': [
+      'Avg daily transactions: 125',
+      'Peak hour: 12pm-1pm',
+    ],
+    'Avg. Basket Size': [
+      'Yesterday: €15.03',
+      'Last week avg: €14.54',
+    ],
+    'Top Product': [
+      'Units sold today: 120',
+      'Weekly sales: 640',
+    ],
+    'Returns Today': [
+      'Returns this week: 47',
+      'Most returned item: Soft Drink 500ml',
+    ],
+    'Low Inventory': [
+      'Orders pending: 3',
+      'Restock ETA: 2 days',
+    ],
+  };
+}

--- a/crm_retail_app/lib/screens/tabs/home_tab.dart
+++ b/crm_retail_app/lib/screens/tabs/home_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import '../metric_detail_screen.dart';
 
 /// Model representing a quick metric shown at the top of the dashboard.
 
@@ -25,45 +26,56 @@ class SummaryCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Card(
-      elevation: 4,
-      color: theme.cardColor,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          children: [
-            Container(
-              padding: const EdgeInsets.all(10),
-              decoration: BoxDecoration(
-                color: metric.color.withOpacity(0.1),
-                shape: BoxShape.circle,
+    return InkWell(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => MetricDetailScreen(metric: metric),
+          ),
+        );
+      },
+      borderRadius: BorderRadius.circular(14),
+      child: Card(
+        elevation: 4,
+        color: theme.cardColor,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: metric.color.withOpacity(0.1),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(metric.icon, size: 28, color: metric.color),
               ),
-              child: Icon(metric.icon, size: 28, color: metric.color),
-            ),
-            const SizedBox(width: 14),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    metric.title,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: Colors.grey,
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      metric.title,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: Colors.grey,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    metric.value,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: theme.textTheme.bodyLarge?.color,
+                    const SizedBox(height: 4),
+                    Text(
+                      metric.value,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: theme.textTheme.bodyLarge?.color,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- make SummaryCard tapable using `InkWell`
- on tap, open new `MetricDetailScreen` that shows extra KPIs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687298ffdac48324a28b26338c3779ff