### PR TITLE
Add API service scaffolding

### DIFF
--- a/crm_retail_app/lib/features/dashboard/metric_detail_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/metric_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'tabs/home_tab.dart';
+import '../../models/dashboard_models.dart';
 
 class MetricDetailScreen extends StatelessWidget {
   final SummaryMetric metric;

--- a/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'tabs/home_tab.dart';
+import '../../models/dashboard_models.dart';
 
 class StoreDetailScreen extends StatelessWidget {
   final StoreSales sales;

--- a/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
@@ -2,22 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import '../metric_detail_screen.dart';
 import '../store_detail_screen.dart';
-
-/// Model representing a quick metric shown at the top of the dashboard.
-
-class SummaryMetric {
-  final String title;
-  final String value;
-  final IconData icon;
-  final Color color;
-
-  SummaryMetric({
-    required this.title,
-    required this.value,
-    required this.icon,
-    required this.color,
-  });
-}
+import '../../../models/dashboard_models.dart';
 
 class SummaryCard extends StatelessWidget {
   final SummaryMetric metric;
@@ -81,12 +66,7 @@ class SummaryCard extends StatelessWidget {
   }
 }
 
-class SalesSeries {
-  final String day;
-  final double sales;
 
-  SalesSeries(this.day, this.sales);
-}
 
 class SalesBarChart extends StatelessWidget {
   final List<SalesSeries> data;
@@ -182,19 +162,6 @@ class SalesTrendCard extends StatelessWidget {
   }
 }
 
-/// Simple customer model used for the recent customers section.
-class RecentCustomer {
-  final String name;
-  final double totalSpent;
-  final String lastPurchase;
-
-  RecentCustomer({
-    required this.name,
-    required this.totalSpent,
-    required this.lastPurchase,
-  });
-}
-
 /// Displays basic information about a customer.
 class RecentCustomerTile extends StatelessWidget {
   final RecentCustomer customer;
@@ -210,20 +177,6 @@ class RecentCustomerTile extends StatelessWidget {
       trailing: Text(customer.lastPurchase),
     );
   }
-}
-
-class StoreSales {
-  final String store;
-  final double lastYear;
-  final double thisYear;
-
-  StoreSales({
-    required this.store,
-    required this.lastYear,
-    required this.thisYear,
-  });
-
-  double get percentChange => ((thisYear - lastYear) / lastYear) * 100;
 }
 
 enum StoreFilter { all, positive, negative }

--- a/crm_retail_app/lib/features/dashboard/tabs/inventory_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/inventory_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'home_tab.dart';
+import '../../../models/dashboard_models.dart';
 
 class InventoryTab extends StatelessWidget {
   const InventoryTab({super.key});

--- a/crm_retail_app/lib/features/dashboard/tabs/sales_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/sales_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'home_tab.dart';
+import '../../../models/dashboard_models.dart';
 
 /// Sales tab showing KPIs for both B2C and B2B online sales.
 class SalesTab extends StatelessWidget {

--- a/crm_retail_app/lib/models/dashboard_models.dart
+++ b/crm_retail_app/lib/models/dashboard_models.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+/// Basic data model representing a quick dashboard metric.
+class SummaryMetric {
+  final String title;
+  final String value;
+  final IconData icon;
+  final Color color;
+
+  SummaryMetric({
+    required this.title,
+    required this.value,
+    required this.icon,
+    required this.color,
+  });
+}
+
+/// Simple series used for sales charts.
+class SalesSeries {
+  final String day;
+  final double sales;
+
+  SalesSeries(this.day, this.sales);
+}
+
+/// Recent customer information for the dashboard.
+class RecentCustomer {
+  final String name;
+  final double totalSpent;
+  final String lastPurchase;
+
+  RecentCustomer({
+    required this.name,
+    required this.totalSpent,
+    required this.lastPurchase,
+  });
+}
+
+/// Sales data per store for comparison tables.
+class StoreSales {
+  final String store;
+  final double lastYear;
+  final double thisYear;
+
+  StoreSales({
+    required this.store,
+    required this.lastYear,
+    required this.thisYear,
+  });
+
+  double get percentChange => ((thisYear - lastYear) / lastYear) * 100;
+}

--- a/crm_retail_app/lib/services/api_routes.dart
+++ b/crm_retail_app/lib/services/api_routes.dart
@@ -1,0 +1,11 @@
+/// Defines endpoints used by the application.
+class ApiRoutes {
+  static const baseUrl = 'https://api.example.com';
+
+  static const login = '/auth/login';
+  static const metrics = '/dashboard/metrics';
+  static const storeSales = '/stores/sales';
+  static const weeklySales = '/sales/weekly';
+  static const hourlySales = '/sales/hourly';
+  static const inventory = '/inventory';
+}

--- a/crm_retail_app/lib/services/api_service.dart
+++ b/crm_retail_app/lib/services/api_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/dashboard_models.dart';
+import 'api_routes.dart';
+
+/// Basic HTTP client for the real API.
+class ApiService {
+  ApiService({this.baseUrl = ApiRoutes.baseUrl});
+
+  final String baseUrl;
+
+  Uri _uri(String path) => Uri.parse('$baseUrl$path');
+
+  Future<List<SummaryMetric>> fetchMetrics() async {
+    final res = await http.get(_uri(ApiRoutes.metrics));
+    final data = jsonDecode(res.body) as List<dynamic>;
+    return data
+        .map((e) => SummaryMetric(
+              title: e['title'],
+              value: e['value'],
+              icon: Icons.insert_chart, // placeholder
+              color: Colors.teal,
+            ))
+        .toList();
+  }
+
+  Future<List<StoreSales>> fetchStoreSales() async {
+    final res = await http.get(_uri(ApiRoutes.storeSales));
+    final data = jsonDecode(res.body) as List<dynamic>;
+    return data
+        .map((e) => StoreSales(
+              store: e['store'],
+              lastYear: (e['lastYear'] as num).toDouble(),
+              thisYear: (e['thisYear'] as num).toDouble(),
+            ))
+        .toList();
+  }
+}

--- a/crm_retail_app/lib/services/mock_api_service.dart
+++ b/crm_retail_app/lib/services/mock_api_service.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+import '../models/dashboard_models.dart';
+
+/// Returns hard coded data used during development.
+class MockApiService {
+  Future<List<SummaryMetric>> fetchMetrics() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return [
+      SummaryMetric(
+        title: 'Total Revenue',
+        value: '€12,430',
+        icon: Icons.attach_money,
+        color: Colors.green,
+      ),
+      SummaryMetric(
+        title: 'Transactions',
+        value: '845',
+        icon: Icons.shopping_cart_checkout,
+        color: Colors.blue,
+      ),
+      SummaryMetric(
+        title: 'Avg. Basket Size',
+        value: '€14.71',
+        icon: Icons.shopping_bag,
+        color: Colors.indigo,
+      ),
+      SummaryMetric(
+        title: 'Top Product',
+        value: 'Milk 1L',
+        icon: Icons.star,
+        color: Colors.amber,
+      ),
+      SummaryMetric(
+        title: 'Returns Today',
+        value: '12',
+        icon: Icons.undo,
+        color: Colors.redAccent,
+      ),
+      SummaryMetric(
+        title: 'Low Inventory',
+        value: '5 Items',
+        icon: Icons.inventory_2,
+        color: Colors.orange,
+      ),
+    ];
+  }
+
+  Future<List<SalesSeries>> fetchWeeklySales() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return [
+      SalesSeries('Mon', 200),
+      SalesSeries('Tue', 350),
+      SalesSeries('Wed', 280),
+      SalesSeries('Thu', 400),
+      SalesSeries('Fri', 500),
+      SalesSeries('Sat', 450),
+      SalesSeries('Sun', 320),
+    ];
+  }
+
+  Future<List<SalesSeries>> fetchHourlySales() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return List.generate(17, (i) {
+      int hour = 8 + i;
+      return SalesSeries('${hour}h', 100 + i * 5);
+    });
+  }
+
+  Future<List<StoreSales>> fetchStoreSales() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return List.generate(120, (i) {
+      return StoreSales(
+        store: 'VFS${i + 1}',
+        lastYear: 10000 + i * 600,
+        thisYear: 12000 + i * 650 - (i % 5 == 0 ? 3000 : 0),
+      );
+    });
+  }
+
+  Future<List<RecentCustomer>> fetchRecentCustomers() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return [
+      RecentCustomer(
+        name: 'Alice Johnson',
+        totalSpent: 250.50,
+        lastPurchase: '12 Sep',
+      ),
+      RecentCustomer(
+        name: 'Bob Smith',
+        totalSpent: 190.00,
+        lastPurchase: '10 Sep',
+      ),
+      RecentCustomer(
+        name: 'Caroline Lee',
+        totalSpent: 320.10,
+        lastPurchase: '09 Sep',
+      ),
+    ];
+  }
+}

--- a/crm_retail_app/pubspec.yaml
+++ b/crm_retail_app/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
     sdk: flutter
   fl_chart: ^0.64.0
   provider: ^6.1.0
+  http: ^1.1.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- centralize data models in `dashboard_models.dart`
- introduce `ApiRoutes` constants
- add `ApiService` for real API calls
- add `MockApiService` returning hard-coded data
- update feature widgets to import shared models
- declare `http` dependency

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `apt-get install dart-sdk` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_6873f49d15c083249ed81ce0e0109b42