### PR TITLE
Enhance CRM app with theme toggle and store search

### DIFF
--- a/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
@@ -193,6 +193,13 @@ class StoreSalesTable extends StatefulWidget {
 class _StoreSalesTableState extends State<StoreSalesTable> {
   bool sortAscending = false;
   StoreFilter filter = StoreFilter.all;
+  final TextEditingController _searchCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
+  }
 
   void _showStoreDetails(StoreSales sales) {
     Navigator.push(
@@ -202,17 +209,22 @@ class _StoreSalesTableState extends State<StoreSalesTable> {
   }
 
   List<StoreSales> get filteredSortedData {
-    final filtered =
-        widget.salesData.where((s) {
-          switch (filter) {
-            case StoreFilter.positive:
-              return s.percentChange > 0;
-            case StoreFilter.negative:
-              return s.percentChange < 0;
-            default:
-              return true;
-          }
-        }).toList();
+    final filtered = widget.salesData.where((s) {
+      switch (filter) {
+        case StoreFilter.positive:
+          return s.percentChange > 0;
+        case StoreFilter.negative:
+          return s.percentChange < 0;
+        default:
+          return true;
+      }
+    }).toList();
+
+    if (_searchCtrl.text.isNotEmpty) {
+      final query = _searchCtrl.text.toLowerCase();
+      filtered.retainWhere(
+          (s) => s.store.toLowerCase().contains(query));
+    }
 
     filtered.sort(
       (a, b) =>
@@ -244,28 +256,37 @@ class _StoreSalesTableState extends State<StoreSalesTable> {
                   value: StoreFilter.positive,
                   child: Text("Positive"),
                 ),
-                DropdownMenuItem(
-                  value: StoreFilter.negative,
-                  child: Text("Negative"),
-                ),
-              ],
+              DropdownMenuItem(
+                value: StoreFilter.negative,
+                child: Text("Negative"),
+              ),
+            ],
             ),
-            const SizedBox(width: 24),
-            Row(
-              children: [
-                const Text("Ascending"),
-                Switch(
-                  value: sortAscending,
-                  onChanged: (val) => setState(() => sortAscending = val),
-                ),
-              ],
+        const SizedBox(width: 24),
+        Row(
+          children: [
+            const Text("Ascending"),
+            Switch(
+              value: sortAscending,
+              onChanged: (val) => setState(() => sortAscending = val),
             ),
           ],
         ),
-        const SizedBox(height: 12),
-        ListView.separated(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
+      ],
+    ),
+    const SizedBox(height: 12),
+    TextField(
+      controller: _searchCtrl,
+      decoration: const InputDecoration(
+        prefixIcon: Icon(Icons.search),
+        hintText: 'Search stores',
+      ),
+      onChanged: (_) => setState(() {}),
+    ),
+    const SizedBox(height: 12),
+    ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
           itemCount: filteredSortedData.length,
           separatorBuilder: (_, __) => const SizedBox(height: 12),
           itemBuilder: (context, index) {

--- a/crm_retail_app/lib/features/dashboard/tabs/settings_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/settings_tab.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../theme/theme_notifier.dart';
 
 class SettingsTab extends StatelessWidget {
   const SettingsTab({super.key});
@@ -18,10 +20,15 @@ class SettingsTab extends StatelessWidget {
             title: const Text("Profile"),
             onTap: () {}, // Navigate to profile settings
           ),
-          ListTile(
-            leading: const Icon(Icons.palette),
-            title: const Text("Theme"),
-            onTap: () {}, // Toggle theme if implemented
+          Consumer<ThemeNotifier>(
+            builder: (context, themeNotifier, _) {
+              return SwitchListTile(
+                secondary: const Icon(Icons.palette),
+                title: const Text('Dark Mode'),
+                value: themeNotifier.isDarkMode,
+                onChanged: (_) => themeNotifier.toggle(),
+              );
+            },
           ),
           ListTile(
             leading: const Icon(Icons.logout),

--- a/crm_retail_app/lib/features/theme/theme_notifier.dart
+++ b/crm_retail_app/lib/features/theme/theme_notifier.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Handles persisting and toggling the application's theme mode.
+class ThemeNotifier extends ChangeNotifier {
+  static const _prefKey = 'isDarkMode';
+
+  bool _isDarkMode = true;
+  bool get isDarkMode => _isDarkMode;
+
+  ThemeNotifier() {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _isDarkMode = prefs.getBool(_prefKey) ?? true;
+    notifyListeners();
+  }
+
+  Future<void> toggle() async {
+    _isDarkMode = !_isDarkMode;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_prefKey, _isDarkMode);
+  }
+}

--- a/crm_retail_app/lib/main.dart
+++ b/crm_retail_app/lib/main.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'features/auth/login_screen.dart';
 import 'features/theme/misty_dark_theme.dart';
+import 'features/theme/theme_notifier.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => ThemeNotifier(),
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -11,11 +18,17 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Retail CRM',
-      theme: mistyDarkTheme,
-      home: const LoginScreen(),
-      debugShowCheckedModeBanner: false,
+    return Consumer<ThemeNotifier>(
+      builder: (context, theme, _) {
+        return MaterialApp(
+          title: 'Retail CRM',
+          theme: ThemeData.light(),
+          darkTheme: mistyDarkTheme,
+          themeMode: theme.isDarkMode ? ThemeMode.dark : ThemeMode.light,
+          home: const LoginScreen(),
+          debugShowCheckedModeBanner: false,
+        );
+      },
     );
   }
 }

--- a/crm_retail_app/pubspec.yaml
+++ b/crm_retail_app/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   fl_chart: ^0.64.0
   provider: ^6.1.0
   http: ^1.1.0
+  shared_preferences: ^2.2.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add `shared_preferences` dependency
- create `ThemeNotifier` for persisting dark mode
- wire up theme provider in `main.dart`
- add a dark mode switch in Settings
- allow searching stores in StoreSales table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6873f9e56d548324b49cdd8ef067fcb2