### PR TITLE
Add authentication with 2FA and SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+service/crm.db

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(24)
+               languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 
@@ -18,12 +18,14 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	runtimeOnly 'com.h2database:h2'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+       implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+       implementation 'org.springframework.boot:spring-boot-starter-validation'
+       implementation 'org.springframework.boot:spring-boot-starter-web'
+       implementation 'org.springframework.boot:spring-boot-starter-security'
+       runtimeOnly 'org.xerial:sqlite-jdbc:3.45.3.0'
+       implementation 'org.hibernate.orm:hibernate-community-dialects:6.6.18.Final'
+       testImplementation 'org.springframework.boot:spring-boot-starter-test'
+       testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/service/src/main/java/com/vivacrm/crm/config/SecurityConfig.java
+++ b/service/src/main/java/com/vivacrm/crm/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.vivacrm.crm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/auth/**").permitAll()
+                .anyRequest().authenticated())
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/service/src/main/java/com/vivacrm/crm/controller/AuthController.java
+++ b/service/src/main/java/com/vivacrm/crm/controller/AuthController.java
@@ -1,0 +1,60 @@
+package com.vivacrm.crm.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.vivacrm.crm.user.User;
+import com.vivacrm.crm.user.UserRepository;
+import com.vivacrm.crm.user.UserService;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    public AuthController(AuthenticationManager authenticationManager, UserService userService, UserRepository userRepository) {
+        this.authenticationManager = authenticationManager;
+        this.userService = userService;
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody Map<String, String> body) {
+        String username = body.get("username");
+        String password = body.get("password");
+        User user = userService.register(username, password);
+        return ResponseEntity.ok(Map.of("totpSecret", user.getTotpSecret()));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody Map<String, String> body) {
+        String username = body.get("username");
+        String password = body.get("password");
+        String otp = body.get("otp");
+        try {
+            Authentication auth = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(username, password));
+            User user = userRepository.findByUsername(username).orElseThrow();
+            if (user.isTotpEnabled()) {
+                if (otp == null || !userService.verifyTotp(user, otp)) {
+                    return ResponseEntity.status(403).body("Invalid OTP");
+                }
+            }
+            return ResponseEntity.ok("Authenticated");
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(401).build();
+        }
+    }
+}

--- a/service/src/main/java/com/vivacrm/crm/security/CustomUserDetailsService.java
+++ b/service/src/main/java/com/vivacrm/crm/security/CustomUserDetailsService.java
@@ -1,0 +1,38 @@
+package com.vivacrm.crm.security;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.vivacrm.crm.user.User;
+import com.vivacrm.crm.user.UserRepository;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                getAuthorities());
+    }
+
+    private Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("USER"));
+    }
+}

--- a/service/src/main/java/com/vivacrm/crm/security/TotpUtil.java
+++ b/service/src/main/java/com/vivacrm/crm/security/TotpUtil.java
@@ -1,0 +1,46 @@
+package com.vivacrm.crm.security;
+
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+public final class TotpUtil {
+    private static final long TIME_STEP_SECONDS = 30L;
+    private static final int OTP_DIGITS = 6;
+    private static final String HMAC_ALGORITHM = "HmacSHA1";
+
+    private TotpUtil() {
+    }
+
+    public static String generateSecret() {
+        byte[] buffer = new byte[20];
+        new SecureRandom().nextBytes(buffer);
+        return Base64.getEncoder().encodeToString(buffer);
+    }
+
+    public static boolean verifyCode(String secret, String code) {
+        try {
+            byte[] keyBytes = Base64.getDecoder().decode(secret);
+            SecretKeySpec keySpec = new SecretKeySpec(keyBytes, HMAC_ALGORITHM);
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(keySpec);
+            long timeWindow = Instant.now().getEpochSecond() / TIME_STEP_SECONDS;
+            byte[] data = ByteBuffer.allocate(8).putLong(timeWindow).array();
+            byte[] hash = mac.doFinal(data);
+            int offset = hash[hash.length - 1] & 0xF;
+            int binary = ((hash[offset] & 0x7f) << 24)
+                    | ((hash[offset + 1] & 0xff) << 16)
+                    | ((hash[offset + 2] & 0xff) << 8)
+                    | (hash[offset + 3] & 0xff);
+            int otp = binary % (int) Math.pow(10, OTP_DIGITS);
+            String generated = String.format("%0" + OTP_DIGITS + "d", otp);
+            return generated.equals(code);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/service/src/main/java/com/vivacrm/crm/user/User.java
+++ b/service/src/main/java/com/vivacrm/crm/user/User.java
@@ -1,0 +1,63 @@
+package com.vivacrm.crm.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Column;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String totpSecret;
+    private boolean totpEnabled;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getTotpSecret() {
+        return totpSecret;
+    }
+
+    public void setTotpSecret(String totpSecret) {
+        this.totpSecret = totpSecret;
+    }
+
+    public boolean isTotpEnabled() {
+        return totpEnabled;
+    }
+
+    public void setTotpEnabled(boolean totpEnabled) {
+        this.totpEnabled = totpEnabled;
+    }
+}

--- a/service/src/main/java/com/vivacrm/crm/user/UserRepository.java
+++ b/service/src/main/java/com/vivacrm/crm/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.vivacrm.crm.user;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/service/src/main/java/com/vivacrm/crm/user/UserService.java
+++ b/service/src/main/java/com/vivacrm/crm/user/UserService.java
@@ -1,0 +1,31 @@
+package com.vivacrm.crm.user;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.vivacrm.crm.security.TotpUtil;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User register(String username, String password) {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(passwordEncoder.encode(password));
+        user.setTotpSecret(TotpUtil.generateSecret());
+        user.setTotpEnabled(true);
+        return userRepository.save(user);
+    }
+
+    public boolean verifyTotp(User user, String code) {
+        return TotpUtil.verifyCode(user.getTotpSecret(), code);
+    }
+}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=crm
+spring.datasource.url=jdbc:sqlite:crm.db
+spring.datasource.driver-class-name=org.sqlite.JDBC
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- use Java 21 toolchain and add Spring Security
- switch datasource to SQLite with built-in dialect
- add password hashing and basic auth filter chain
- implement TOTP-based two-factor authentication
- add user entity/repository/service and auth controller
- ignore generated SQLite database

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68760593af54832495b9922de2e8a506