### PR TITLE
Fix device token not persisted

### DIFF
--- a/service/src/main/java/com/vivacrm/crm/controller/AuthController.java
+++ b/service/src/main/java/com/vivacrm/crm/controller/AuthController.java
@@ -77,7 +77,10 @@ public class AuthController {
                             .build();
                     return ResponseEntity.ok()
                             .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                            .body(Map.of("authenticated", true));
+                            .body(Map.of(
+                                    "authenticated", true,
+                                    "deviceToken", deviceToken
+                            ));
                 }
 
                 // ✅ Enforce OTP if deviceToken is not valid
@@ -99,7 +102,10 @@ public class AuthController {
                             .build();
                     return ResponseEntity.ok()
                             .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                            .body(Map.of("authenticated", true));
+                            .body(Map.of(
+                                    "authenticated", true,
+                                    "deviceToken", newToken
+                            ));
                 }
 
                 // If OTP passed, but user didn’t choose to remember device


### PR DESCRIPTION
## Summary
- return the device token in successful login responses so the Flutter client can store it

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68778fc4fedc8324b15d7e52779584f5