### PR TITLE
Preserve device token on logout

### DIFF
--- a/crm_retail_app/lib/features/dashboard/tabs/settings_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/settings_tab.dart
@@ -63,7 +63,9 @@ class SettingsTab extends StatelessWidget {
               );
 
               if (confirm == true) {
-                context.read<UserProvider>().clear(); // ✅ Clear username
+                // Preserve the device token so a trusted device
+                // continues to bypass OTP on next login.
+                context.read<UserProvider>().clear();
                 // Optionally clear other user data if needed
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Logged out successfully')),

--- a/crm_retail_app/lib/providers/user_provider.dart
+++ b/crm_retail_app/lib/providers/user_provider.dart
@@ -48,16 +48,27 @@ class UserProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> clear() async {
+  /// Clears the stored username. The device token is kept so a trusted
+  /// device can still bypass OTP on the next login. Pass `true` to
+  /// [removeDeviceToken] to wipe the token as well.
+  Future<void> clear({bool removeDeviceToken = false}) async {
     _username = '';
-    _deviceToken = '';
+    if (removeDeviceToken) {
+      _deviceToken = '';
+    }
+
     try {
       await _secureStorage.delete(key: _keyUsername);
-      await _secureStorage.delete(key: _keyDeviceToken);
-      debugPrint('🧹 [UserProvider] Cleared username and deviceToken');
+      if (removeDeviceToken) {
+        await _secureStorage.delete(key: _keyDeviceToken);
+        debugPrint('🧹 [UserProvider] Cleared username and deviceToken');
+      } else {
+        debugPrint('🧹 [UserProvider] Cleared username');
+      }
     } catch (e) {
       debugPrint('❌ [UserProvider] Failed to clear secure storage: $e');
     }
+
     notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- keep device token when logging out so trusted devices still skip OTP
- clarify logout behavior in settings screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877acca299083248545da93e2e40f9f