### PR TITLE
Connect dashboard to backend API

### DIFF
--- a/crm_retail_app/lib/models/dashboard_models.dart
+++ b/crm_retail_app/lib/models/dashboard_models.dart
@@ -50,3 +50,21 @@ class StoreSales {
 
   double get percentChange => ((thisYear - lastYear) / lastYear) * 100;
 }
+
+/// Aggregated payload returned from the backend for the dashboard screen.
+///
+/// It contains summary metrics, time series data for daily/hourly sales and
+/// comparative store sales figures.
+class DashboardData {
+  final List<SummaryMetric> metrics;
+  final List<SalesSeries> dailySales;
+  final List<SalesSeries> hourlySales;
+  final List<StoreSales> storeSales;
+
+  DashboardData({
+    required this.metrics,
+    required this.dailySales,
+    required this.hourlySales,
+    required this.storeSales,
+  });
+}

--- a/crm_retail_app/lib/services/api_routes.dart
+++ b/crm_retail_app/lib/services/api_routes.dart
@@ -1,5 +1,9 @@
 class ApiRoutes {
-  static const baseUrl = 'http://192.168.201.20:8080';
+  /// Base URL for the backend service. Updated to use localhost so the
+  /// Flutter app can communicate with the Spring Boot server running on the
+  /// same machine or emulator.
+  static const baseUrl = 'http://localhost:8080';
+
   static const login = '/auth/login';
   static const logout = '/auth/logout';
   static const register = '/auth/register';


### PR DESCRIPTION
## Summary
- point Flutter app to localhost backend and parse dashboard payload
- add DashboardData model and API service to fetch metrics and store sales
- load dashboard tab from backend instead of static data

## Testing
- `dart format crm_retail_app/lib/services/api_routes.dart crm_retail_app/lib/models/dashboard_models.dart crm_retail_app/lib/services/api_service.dart crm_retail_app/lib/features/dashboard/tabs/home_tab.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3848b4488324a2189fe9bc6cdfa4