### PR TITLE
Populate store detail metrics from KPI endpoint

### DIFF
--- a/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
@@ -2,60 +2,79 @@ import 'package:flutter/material.dart';
 import '../../models/dashboard_models.dart';
 
 class StoreDetailScreen extends StatelessWidget {
-  final StoreSales sales;
+  final StoreKpiMetrics metrics;
 
-  const StoreDetailScreen({super.key, required this.sales});
+  const StoreDetailScreen({super.key, required this.metrics});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
     final List<StoreKpi> salesKpis = [
+      StoreKpi('Revenue Today', '€${metrics.revenueToday.toStringAsFixed(2)}',
+          Icons.today),
+      StoreKpi('Revenue PY', '€${metrics.revenuePy.toStringAsFixed(2)}',
+          Icons.calendar_today),
       StoreKpi(
-        'Last Year',
-        '€${sales.lastYear.toStringAsFixed(2)}',
-        Icons.calendar_today,
-      ),
-      StoreKpi(
-        'This Year',
-        '€${sales.thisYear.toStringAsFixed(2)}',
-        Icons.today,
-      ),
-      StoreKpi(
-        'Change',
-        '${sales.percentChange.toStringAsFixed(1)}%',
-        sales.percentChange > 0
+        'Revenue %',
+        '${metrics.revenuePct.toStringAsFixed(1)}%',
+        metrics.revenuePct >= 0
             ? Icons.arrow_upward
-            : sales.percentChange < 0
-            ? Icons.arrow_downward
-            : Icons.remove,
+            : metrics.revenuePct < 0
+                ? Icons.arrow_downward
+                : Icons.remove,
       ),
-      StoreKpi('Revenue/Tx', '€14.20', Icons.calculate),
+      StoreKpi('Avg Basket',
+          '€${metrics.avgBasketToday.toStringAsFixed(2)}', Icons.shopping_basket),
     ];
 
     final List<StoreKpi> customerKpis = [
-      StoreKpi('Customers Today', '120', Icons.people),
-      StoreKpi('Repeat Rate', '36%', Icons.replay),
-      StoreKpi('Conversion Rate', '61%', Icons.show_chart),
-      StoreKpi('Avg Time Spent', '8m 20s', Icons.timer),
+      StoreKpi('Tx Today', metrics.txToday.toString(), Icons.receipt_long),
+      StoreKpi('Tx PY', metrics.txPy.toString(), Icons.history),
+      StoreKpi(
+        'Tx %',
+        '${metrics.txPct.toStringAsFixed(1)}%',
+        metrics.txPct >= 0
+            ? Icons.arrow_upward
+            : metrics.txPct < 0
+                ? Icons.arrow_downward
+                : Icons.remove,
+      ),
+      StoreKpi('Avg Basket PY',
+          '€${metrics.avgBasketPy.toStringAsFixed(2)}', Icons.shopping_basket_outlined),
     ];
 
     final List<StoreKpi> inventoryKpis = [
-      StoreKpi('Low Stock Items', '4', Icons.inventory_2),
-      StoreKpi('Top Product', 'Milk 1L', Icons.star),
-      StoreKpi('Restock Time', '3d avg', Icons.timelapse),
-      StoreKpi('Stock Value', '€2,300', Icons.monetization_on),
+      StoreKpi(
+        'Avg Basket Diff',
+        '€${metrics.avgBasketDiff.toStringAsFixed(2)}',
+        metrics.avgBasketDiff >= 0
+            ? Icons.trending_up
+            : Icons.trending_down,
+      ),
+      StoreKpi('Top Product Code', metrics.topArtCode, Icons.qr_code),
+      StoreKpi('Top Product Rev',
+          '€${metrics.topArtRevenue.toStringAsFixed(2)}', Icons.monetization_on),
+      StoreKpi('Top Product', metrics.topArtName, Icons.star),
     ];
 
     final List<StoreKpi> opsKpis = [
-      StoreKpi('Transactions', '85', Icons.receipt_long),
-      StoreKpi('Avg Basket', '€14.20', Icons.shopping_basket),
-      StoreKpi('Peak Hour', '13:00', Icons.access_time),
-      StoreKpi('Refunds Today', '6', Icons.undo),
+      StoreKpi('Revenue Diff',
+          '€${metrics.revenueDiff.toStringAsFixed(2)}',
+          metrics.revenueDiff >= 0
+              ? Icons.arrow_upward
+              : metrics.revenueDiff < 0
+                  ? Icons.arrow_downward
+                  : Icons.remove),
+      StoreKpi('Tx Diff', metrics.txDiff.toString(),
+          metrics.txDiff >= 0 ? Icons.arrow_upward : Icons.arrow_downward),
+      StoreKpi('Peak Hour', metrics.peakHourLabel, Icons.access_time),
+      StoreKpi('Peak Hour Rev',
+          '€${metrics.peakHourRevenue.toStringAsFixed(2)}', Icons.bar_chart),
     ];
 
     return Scaffold(
-      appBar: AppBar(title: Text(sales.store)),
+      appBar: AppBar(title: Text(metrics.storeName)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: ListView(

--- a/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
@@ -205,10 +205,13 @@ class _StoreSalesTableState extends State<StoreSalesTable> {
     super.dispose();
   }
 
-  void _showStoreDetails(StoreSales sales) {
+  Future<void> _showStoreDetails(StoreSales sales) async {
+    final api = ApiService();
+    final metrics = await api.fetchStoreKpi(sales.storeId);
+    if (!mounted) return;
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => StoreDetailScreen(sales: sales)),
+      MaterialPageRoute(builder: (_) => StoreDetailScreen(metrics: metrics)),
     );
   }
 
@@ -541,10 +544,13 @@ class AnimatedStoreSalesTable extends StatelessWidget {
 
   const AnimatedStoreSalesTable({super.key, required this.salesData});
 
-  void _showStoreDetails(BuildContext context, StoreSales sale) {
+  Future<void> _showStoreDetails(BuildContext context, StoreSales sale) async {
+    final api = ApiService();
+    final metrics = await api.fetchStoreKpi(sale.storeId);
+    if (!context.mounted) return;
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => StoreDetailScreen(sales: sale)),
+      MaterialPageRoute(builder: (_) => StoreDetailScreen(metrics: metrics)),
     );
   }
 

--- a/crm_retail_app/lib/models/dashboard_models.dart
+++ b/crm_retail_app/lib/models/dashboard_models.dart
@@ -38,17 +38,89 @@ class RecentCustomer {
 
 /// Sales data per store for comparison tables.
 class StoreSales {
+  final int storeId;
   final String store;
   final double lastYear;
   final double thisYear;
 
   StoreSales({
+    required this.storeId,
     required this.store,
     required this.lastYear,
     required this.thisYear,
   });
 
   double get percentChange => ((thisYear - lastYear) / lastYear) * 100;
+}
+
+/// Detailed KPI metrics for a single store, populated from the
+/// `SP_GetStoreKPI` stored procedure on the backend.
+class StoreKpiMetrics {
+  final int storeId;
+  final String storeName;
+  final double revenueToday;
+  final double revenuePy;
+  final int txToday;
+  final int txPy;
+  final double avgBasketToday;
+  final double avgBasketPy;
+  final double revenueDiff;
+  final double revenuePct;
+  final int txDiff;
+  final double txPct;
+  final double avgBasketDiff;
+  final int peakHour;
+  final String peakHourLabel;
+  final double peakHourRevenue;
+  final String topArtCode;
+  final double topArtRevenue;
+  final String topArtName;
+
+  StoreKpiMetrics({
+    required this.storeId,
+    required this.storeName,
+    required this.revenueToday,
+    required this.revenuePy,
+    required this.txToday,
+    required this.txPy,
+    required this.avgBasketToday,
+    required this.avgBasketPy,
+    required this.revenueDiff,
+    required this.revenuePct,
+    required this.txDiff,
+    required this.txPct,
+    required this.avgBasketDiff,
+    required this.peakHour,
+    required this.peakHourLabel,
+    required this.peakHourRevenue,
+    required this.topArtCode,
+    required this.topArtRevenue,
+    required this.topArtName,
+  });
+
+  factory StoreKpiMetrics.fromJson(Map<String, dynamic> json) {
+    return StoreKpiMetrics(
+      storeId: json['storeId'] as int,
+      storeName: json['storeName'] as String,
+      revenueToday: (json['revenueToday'] as num).toDouble(),
+      revenuePy: (json['revenuePY'] as num).toDouble(),
+      txToday: (json['txToday'] as num).toInt(),
+      txPy: (json['txPY'] as num).toInt(),
+      avgBasketToday: (json['avgBasketToday'] as num).toDouble(),
+      avgBasketPy: (json['avgBasketPY'] as num).toDouble(),
+      revenueDiff: (json['revenueDiff'] as num).toDouble(),
+      revenuePct: (json['revenuePct'] as num).toDouble(),
+      txDiff: (json['txDiff'] as num).toInt(),
+      txPct: (json['txPct'] as num).toDouble(),
+      avgBasketDiff: (json['avgBasketDiff'] as num).toDouble(),
+      peakHour: (json['peakHour'] as num).toInt(),
+      peakHourLabel: json['peakHourLabel'] as String,
+      peakHourRevenue: (json['peakHourRevenue'] as num).toDouble(),
+      topArtCode: json['topArtCode'] as String,
+      topArtRevenue: (json['topArtRevenue'] as num).toDouble(),
+      topArtName: json['topArtName'] as String,
+    );
+  }
 }
 
 /// Aggregated payload returned from the backend for the dashboard screen.

--- a/crm_retail_app/lib/services/api_routes.dart
+++ b/crm_retail_app/lib/services/api_routes.dart
@@ -9,6 +9,7 @@ class ApiRoutes {
   static const register = '/auth/register';
   static const metrics = '/dashboard/metrics';
   static const storeSales = '/stores/sales';
+  static const storeKpi = '/stores/kpi';
   static const weeklySales = '/sales/weekly';
   static const hourlySales = '/sales/hourly';
   static const inventory = '/inventory';

--- a/crm_retail_app/lib/services/api_service.dart
+++ b/crm_retail_app/lib/services/api_service.dart
@@ -103,6 +103,7 @@ class ApiService {
     final stores = (data['storeComparison'] as List<dynamic>? ?? [])
         .map(
           (e) => StoreSales(
+            storeId: e['storeId'] as int,
             store: (e['store'] as String).trim(),
             lastYear: (e['lastYear'] as num).toDouble(),
             thisYear: (e['thisYear'] as num).toDouble(),
@@ -164,12 +165,20 @@ class ApiService {
     return data
         .map(
           (e) => StoreSales(
+            storeId: e['storeId'] as int,
             store: (e['store'] as String).trim(),
             lastYear: (e['lastYear'] as num).toDouble(),
             thisYear: (e['thisYear'] as num).toDouble(),
           ),
         )
         .toList();
+  }
+
+  /// Fetches detailed KPI metrics for a single store.
+  Future<StoreKpiMetrics> fetchStoreKpi(int storeId) async {
+    final res = await http.get(_uri('${ApiRoutes.storeKpi}/$storeId'));
+    final data = jsonDecode(res.body) as Map<String, dynamic>;
+    return StoreKpiMetrics.fromJson(data);
   }
 
   /// Returns whether OTP is enabled for the user.

--- a/crm_retail_app/lib/services/mock_api_service.dart
+++ b/crm_retail_app/lib/services/mock_api_service.dart
@@ -72,10 +72,36 @@ class MockApiService {
     await Future.delayed(const Duration(milliseconds: 300));
     return List.generate(120, (i) {
       return StoreSales(
+        storeId: i + 1,
         store: 'VFS${i + 1}',
         lastYear: 10000 + i * 600,
         thisYear: 12000 + i * 650 - (i % 5 == 0 ? 3000 : 0),
       );
     });
+  }
+
+  Future<StoreKpiMetrics> fetchStoreKpi(int storeId) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return StoreKpiMetrics(
+      storeId: storeId,
+      storeName: 'VFS 01 Ferizaj',
+      revenueToday: 6105.48,
+      revenuePy: 7170.55,
+      txToday: 780,
+      txPy: 1078,
+      avgBasketToday: 7.83,
+      avgBasketPy: 6.65,
+      revenueDiff: -1065.07,
+      revenuePct: -14.85,
+      txDiff: -298,
+      txPct: -27.64,
+      avgBasketDiff: 1.18,
+      peakHour: 18,
+      peakHourLabel: '18h',
+      peakHourRevenue: 723.62,
+      topArtCode: '017419',
+      topArtRevenue: 185.10,
+      topArtName: 'Red Bull 0.25L',
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add StoreKpiMetrics model and storeId field for store comparisons
- fetch store KPI data from `/stores/kpi/{id}` and wire into dashboard UI
- show revenue, transaction, basket and peak-hour metrics on store detail screen

## Testing
- `dart format crm_retail_app/lib/models/dashboard_models.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0beba129483249e2ac9909351f876