### PR TITLE
Fix store KPI endpoint usage in store detail view

### DIFF
--- a/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
@@ -21,9 +21,7 @@ class _StoreDetailScreenState extends State<StoreDetailScreen> {
   @override
   void initState() {
     super.initState();
-    _kpiFuture =
-        ApiService().fetchStoreKpi(widget.sales.storeId)
-            as Future<StoreKpiDetail?>;
+    _kpiFuture = ApiService().fetchStoreKpiDetail(widget.sales.storeId);
   }
 
   @override

--- a/crm_retail_app/lib/services/api_service.dart
+++ b/crm_retail_app/lib/services/api_service.dart
@@ -201,7 +201,7 @@ class ApiService {
 
   /// Fetches detailed KPI metrics for a single store.
   Future<StoreKpiMetrics> fetchStoreKpi(int storeId) async {
-    final res = await http.get(_uri('${ApiRoutes.storeKpi}/$storeId'));
+    final res = await http.get(_uri(ApiRoutes.storeKpi(storeId)));
     final data = jsonDecode(res.body) as Map<String, dynamic>;
     return StoreKpiMetrics.fromJson(data);
   }


### PR DESCRIPTION
## Summary
- use `ApiRoutes.storeKpi(id)` when fetching store KPIs
- load store KPI detail via `fetchStoreKpiDetail` in store detail screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb3ae34c8324980b71b55fa18886