### PR TITLE
feat: add calendar-driven daily calculations

### DIFF
--- a/crm_retail_app/lib/features/dashboard/dashboard_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/dashboard_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:crm_retail_app/features/dashboard/tabs/home_tab.dart';
 import 'package:crm_retail_app/features/dashboard/tabs/sales_tab.dart';
 import 'package:crm_retail_app/features/dashboard/tabs/inventory_tab.dart';
 import 'package:crm_retail_app/features/dashboard/tabs/settings_tab.dart';
+import 'package:crm_retail_app/providers/date_provider.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -26,7 +28,27 @@ class _DashboardScreenState extends State<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(_titles[_currentIndex])),
+      appBar: AppBar(
+        title: Text(_titles[_currentIndex]),
+        actions: [
+          Consumer<DateProvider>(
+            builder: (context, dateProvider, _) => IconButton(
+              icon: const Icon(Icons.calendar_today),
+              onPressed: () async {
+                final picked = await showDatePicker(
+                  context: context,
+                  initialDate: dateProvider.selectedDate,
+                  firstDate: DateTime(2000),
+                  lastDate: DateTime.now(),
+                );
+                if (picked != null) {
+                  dateProvider.setDate(picked);
+                }
+              },
+            ),
+          ),
+        ],
+      ),
       body: _pages[_currentIndex],
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex,

--- a/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import '../../models/dashboard_models.dart';
 import '../../services/api_service.dart';
+import '../../providers/date_provider.dart';
 
 class StoreDetailScreen extends StatefulWidget {
   final StoreSales sales;
@@ -12,16 +15,9 @@ class StoreDetailScreen extends StatefulWidget {
 }
 
 class _StoreDetailScreenState extends State<StoreDetailScreen> {
-  late final Future<StoreKpiDetail?> _kpiFuture;
-
-  @override
-  void initState() {
-    super.initState();
-    _kpiFuture = ApiService().fetchStoreKpiDetail(widget.sales.storeId);
-  }
-
   @override
   Widget build(BuildContext context) {
+    final selectedDate = context.watch<DateProvider>().selectedDate;
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -31,7 +27,8 @@ class _StoreDetailScreenState extends State<StoreDetailScreen> {
         ),
       ),
       body: FutureBuilder<StoreKpiDetail?>(
-        future: _kpiFuture,
+        future:
+            ApiService().fetchStoreKpiDetail(widget.sales.storeId, date: selectedDate),
         builder: (context, snap) {
           if (snap.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());

--- a/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
@@ -3,11 +3,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:provider/provider.dart';
 
 import '../metric_detail_screen.dart';
 import '../store_detail_screen.dart';
 import '../../../models/dashboard_models.dart';
 import '../../../services/api_service.dart';
+import '../../../providers/date_provider.dart';
 
 /// =======================
 /// Summary KPI card
@@ -577,12 +579,22 @@ class _HomeTabState extends State<HomeTab> {
 
   Timer? _timer;
   Duration _timeLeft = const Duration(minutes: 11);
+  DateTime? _currentDate;
 
   @override
   void initState() {
     super.initState();
-    _future = _api.fetchDashboard();
     _startTimer();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final date = context.watch<DateProvider>().selectedDate;
+    if (_currentDate != date) {
+      _currentDate = date;
+      _setFuture();
+    }
   }
 
   void _startTimer() {
@@ -598,11 +610,13 @@ class _HomeTabState extends State<HomeTab> {
     });
   }
 
+  void _setFuture() {
+    _future = _api.fetchDashboard(date: _currentDate);
+    _timeLeft = const Duration(minutes: 11);
+  }
+
   void _refreshData() {
-    setState(() {
-      _future = _api.fetchDashboard();
-      _timeLeft = const Duration(minutes: 11);
-    });
+    setState(_setFuture);
   }
 
   String _formatDuration(Duration d) {

--- a/crm_retail_app/lib/main.dart
+++ b/crm_retail_app/lib/main.dart
@@ -4,6 +4,7 @@ import 'features/auth/login_screen.dart';
 import 'features/theme/misty_dark_theme.dart';
 import 'features/theme/theme_notifier.dart';
 import 'providers/user_provider.dart';
+import 'providers/date_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -17,6 +18,7 @@ void main() async {
       providers: [
         ChangeNotifierProvider(create: (_) => ThemeNotifier()),
         ChangeNotifierProvider.value(value: userProvider),
+        ChangeNotifierProvider(create: (_) => DateProvider()),
       ],
       child: MyApp(userProvider: userProvider), // ✅ FIXED HERE
     ),
@@ -29,24 +31,18 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider(create: (_) => ThemeNotifier()),
-        ChangeNotifierProvider.value(value: userProvider),
-      ],
-      child: Consumer<ThemeNotifier>(
-        builder: (context, theme, _) {
-          return MaterialApp(
-            title: 'Retail CRM',
-            theme: ThemeData.light(),
-            darkTheme: mistyDarkTheme,
-            themeMode: theme.isDarkMode ? ThemeMode.dark : ThemeMode.light,
-            debugShowCheckedModeBanner: false,
-            initialRoute: '/login',
-            routes: {'/login': (context) => const LoginScreen()},
-          );
-        },
-      ),
+    return Consumer<ThemeNotifier>(
+      builder: (context, theme, _) {
+        return MaterialApp(
+          title: 'Retail CRM',
+          theme: ThemeData.light(),
+          darkTheme: mistyDarkTheme,
+          themeMode: theme.isDarkMode ? ThemeMode.dark : ThemeMode.light,
+          debugShowCheckedModeBanner: false,
+          initialRoute: '/login',
+          routes: {'/login': (context) => const LoginScreen()},
+        );
+      },
     );
   }
 }

--- a/crm_retail_app/lib/providers/date_provider.dart
+++ b/crm_retail_app/lib/providers/date_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+/// Holds the currently selected date for dashboard calculations.
+class DateProvider extends ChangeNotifier {
+  DateTime _selectedDate = DateTime.now();
+
+  DateTime get selectedDate => _selectedDate;
+
+  /// Updates the selected date and notifies listeners if changed.
+  void setDate(DateTime date) {
+    if (!_isSameDay(_selectedDate, date)) {
+      _selectedDate = date;
+      notifyListeners();
+    }
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+}

--- a/crm_retail_app/lib/services/api_service.dart
+++ b/crm_retail_app/lib/services/api_service.dart
@@ -12,6 +12,11 @@ class ApiService {
   final String baseUrl;
 
   Uri _uri(String path) => Uri.parse('$baseUrl$path');
+  Uri _uriWithDate(String path, DateTime? date) {
+    if (date == null) return _uri(path);
+    final formatted = date.toIso8601String().split('T').first;
+    return Uri.parse('$baseUrl$path?date=$formatted');
+  }
 
   /// Attempts to authenticate a user. Returns the raw HTTP response so
   /// callers can inspect the status code and body. A 200 response indicates
@@ -79,8 +84,8 @@ class ApiService {
   /// Fetches dashboard data including metrics, sales series and store
   /// comparisons. The backend returns a `DashboardPayload` object which is
   /// mapped into strongly typed models for the UI layer.
-  Future<DashboardData> fetchDashboard() async {
-    final res = await http.get(_uri(ApiRoutes.metrics));
+  Future<DashboardData> fetchDashboard({DateTime? date}) async {
+    final res = await http.get(_uriWithDate(ApiRoutes.metrics, date));
     final data = jsonDecode(res.body) as Map<String, dynamic>;
 
     final metrics =
@@ -155,8 +160,9 @@ class ApiService {
     );
   }
 
-  Future<StoreKpiDetail?> fetchStoreKpiDetail(int storeId) async {
-    final res = await http.get(_uri(ApiRoutes.storeKpi(storeId)));
+  Future<StoreKpiDetail?> fetchStoreKpiDetail(int storeId,
+      {DateTime? date}) async {
+    final res = await http.get(_uriWithDate(ApiRoutes.storeKpi(storeId), date));
     if (res.statusCode != 200) return null;
     final data = jsonDecode(res.body) as Map<String, dynamic>;
     return StoreKpiDetail.fromJson(data);


### PR DESCRIPTION
## Summary
- add `DateProvider` to hold globally selected date
- show calendar picker in dashboard app bar
- query dashboard and store APIs for the chosen day

## Testing
- `dart format crm_retail_app/lib/main.dart crm_retail_app/lib/providers/date_provider.dart crm_retail_app/lib/features/dashboard/dashboard_screen.dart crm_retail_app/lib/features/dashboard/tabs/home_tab.dart crm_retail_app/lib/services/api_service.dart crm_retail_app/lib/features/dashboard/store_detail_screen.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42ec8016c8324900b1c558494eeca