### PR TITLE
Support optional time parameter for dashboard metrics

### DIFF
--- a/crm_retail_app/lib/providers/date_provider.dart
+++ b/crm_retail_app/lib/providers/date_provider.dart
@@ -6,15 +6,11 @@ class DateProvider extends ChangeNotifier {
 
   DateTime get selectedDate => _selectedDate;
 
-  /// Updates the selected date and notifies listeners if changed.
+  /// Updates the selected date/time and notifies listeners if changed.
   void setDate(DateTime date) {
-    if (!_isSameDay(_selectedDate, date)) {
+    if (!_selectedDate.isAtSameMomentAs(date)) {
       _selectedDate = date;
       notifyListeners();
     }
-  }
-
-  bool _isSameDay(DateTime a, DateTime b) {
-    return a.year == b.year && a.month == b.month && a.day == b.day;
   }
 }

--- a/crm_retail_app/lib/services/api_service.dart
+++ b/crm_retail_app/lib/services/api_service.dart
@@ -14,8 +14,8 @@ class ApiService {
   Uri _uri(String path) => Uri.parse('$baseUrl$path');
   Uri _uriWithDate(String path, DateTime? date) {
     if (date == null) return _uri(path);
-    final formatted = date.toIso8601String().split('T').first;
-    return Uri.parse('$baseUrl$path?date=$formatted');
+    final formatted = date.toIso8601String();
+    return Uri.parse('$baseUrl$path?forDate=$formatted');
   }
 
   /// Attempts to authenticate a user. Returns the raw HTTP response so
@@ -55,8 +55,8 @@ class ApiService {
     }
   }
 
-  Future<List<SummaryMetric>> fetchMetrics() async {
-    final res = await http.get(_uri(ApiRoutes.metrics));
+  Future<List<SummaryMetric>> fetchMetrics({DateTime? date}) async {
+    final res = await http.get(_uriWithDate(ApiRoutes.metrics, date));
     final data = jsonDecode(res.body) as Map<String, dynamic>;
     final metricsJson = data['metrics'] as List<dynamic>? ?? [];
     return metricsJson.map((e) {

--- a/crm_retail_app/lib/services/mock_api_service.dart
+++ b/crm_retail_app/lib/services/mock_api_service.dart
@@ -5,7 +5,7 @@ import '../models/dashboard_models.dart';
 
 /// Returns hard coded data used during development.
 class MockApiService {
-  Future<List<SummaryMetric>> fetchMetrics() async {
+  Future<List<SummaryMetric>> fetchMetrics({DateTime? date}) async {
     await Future.delayed(const Duration(milliseconds: 300));
     return [
       SummaryMetric(

--- a/service/src/main/java/com/vivacrm/crm/controller/DashboardController.java
+++ b/service/src/main/java/com/vivacrm/crm/controller/DashboardController.java
@@ -3,8 +3,10 @@ package com.vivacrm.crm.controller;
 
 import com.vivacrm.crm.service.DashboardService;
 import com.vivacrm.crm.service.dto.DashboardPayload;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/dashboard")
@@ -15,7 +17,14 @@ public class DashboardController {
 
     /** Returns cached metrics unless `refresh=true` is provided. */
     @GetMapping("/metrics")
-    public DashboardPayload metrics(@RequestParam(name = "refresh", defaultValue = "false") boolean refresh) {
+    public DashboardPayload metrics(
+            @RequestParam(name = "refresh", defaultValue = "false") boolean refresh,
+            @RequestParam(name = "forDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime forDate) {
+
+        if (forDate != null) {
+            return dashboardService.getMetrics(forDate);
+        }
         return refresh ? dashboardService.refreshMetrics() : dashboardService.getMetrics();
     }
 


### PR DESCRIPTION
## Summary
- Allow `/dashboard/metrics` to accept optional `forDate` query parameter
- Pass provided date/time to `SP_GetDashboardData` in backend
- Send ISO8601 date-time from Flutter client when a date is selected

## Testing
- `./gradlew test`
- `dart format lib/providers/date_provider.dart lib/services/api_service.dart lib/services/mock_api_service.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4373de7988324ad2db275eb2b064e