### PR TITLE
Add authentication token to API requests

### DIFF
--- a/crm_retail_app/lib/features/auth/login_screen.dart
+++ b/crm_retail_app/lib/features/auth/login_screen.dart
@@ -96,6 +96,14 @@ class _LoginScreenState extends State<LoginScreen> {
           debugPrint('ℹ️ No new deviceToken returned.');
         }
 
+        final authToken = data['token'] as String?;
+        if (authToken != null && authToken.isNotEmpty) {
+          debugPrint('✅ Auth token received');
+          await userProvider.setAuthToken(authToken);
+        } else {
+          debugPrint('ℹ️ No auth token returned.');
+        }
+
         if (!mounted) return;
         Navigator.pushReplacement(
           context,

--- a/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/store_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../models/dashboard_models.dart';
 import '../../services/api_service.dart';
 import '../../providers/date_provider.dart';
+import '../../providers/user_provider.dart';
 
 class StoreDetailScreen extends StatefulWidget {
   final StoreSales sales;
@@ -27,8 +28,9 @@ class _StoreDetailScreenState extends State<StoreDetailScreen> {
         ),
       ),
       body: FutureBuilder<StoreKpiDetail?>(
-        future:
-            ApiService().fetchStoreKpiDetail(widget.sales.storeId, date: selectedDate),
+        future: ApiService(
+          authToken: context.read<UserProvider>().authToken,
+        ).fetchStoreKpiDetail(widget.sales.storeId, date: selectedDate),
         builder: (context, snap) {
           if (snap.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());

--- a/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
@@ -10,6 +10,7 @@ import '../store_detail_screen.dart';
 import '../../../models/dashboard_models.dart';
 import '../../../services/api_service.dart';
 import '../../../providers/date_provider.dart';
+import '../../../providers/user_provider.dart';
 
 /// =======================
 /// Summary KPI card
@@ -574,7 +575,7 @@ class HomeTab extends StatefulWidget {
 }
 
 class _HomeTabState extends State<HomeTab> {
-  final ApiService _api = ApiService();
+  late ApiService _api;
   late Future<DashboardData> _future;
 
   Timer? _timer;
@@ -590,6 +591,7 @@ class _HomeTabState extends State<HomeTab> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _api = ApiService(authToken: context.read<UserProvider>().authToken);
     final date = context.watch<DateProvider>().selectedDate;
     if (_currentDate != date) {
       _currentDate = date;

--- a/crm_retail_app/lib/features/profile/profile_screen.dart
+++ b/crm_retail_app/lib/features/profile/profile_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import '../../services/api_service.dart';
+import '../../providers/user_provider.dart';
 
 class ProfileScreen extends StatefulWidget {
   final String username;
@@ -12,14 +14,19 @@ class ProfileScreen extends StatefulWidget {
 }
 
 class _ProfileScreenState extends State<ProfileScreen> {
-  final ApiService _api = ApiService();
+  late ApiService _api;
   bool _otpEnabled = false;
   bool _loading = true;
+  bool _initialized = false;
 
   @override
-  void initState() {
-    super.initState();
-    _loadOtpStatus();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_initialized) {
+      _api = ApiService(authToken: context.read<UserProvider>().authToken);
+      _loadOtpStatus();
+      _initialized = true;
+    }
   }
 
   Future<void> _loadOtpStatus() async {

--- a/crm_retail_app/lib/providers/user_provider.dart
+++ b/crm_retail_app/lib/providers/user_provider.dart
@@ -4,22 +4,27 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 class UserProvider with ChangeNotifier {
   static const _keyUsername = 'username';
   static const _keyDeviceToken = 'device_token';
+  static const _keyAuthToken = 'auth_token';
 
   final FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
 
   String _username = '';
   String _deviceToken = '';
+  String _authToken = '';
 
   String get username => _username;
   String get deviceToken => _deviceToken;
+  String get authToken => _authToken;
 
   /// Initializes from secure storage
   Future<void> init() async {
     try {
       _username = await _secureStorage.read(key: _keyUsername) ?? '';
       _deviceToken = await _secureStorage.read(key: _keyDeviceToken) ?? '';
+      _authToken = await _secureStorage.read(key: _keyAuthToken) ?? '';
       debugPrint('📦 [UserProvider.init] Loaded username: $_username');
       debugPrint('📦 [UserProvider.init] Loaded deviceToken: $_deviceToken');
+      debugPrint('📦 [UserProvider.init] Loaded authToken: $_authToken');
     } catch (e) {
       debugPrint('❌ [UserProvider.init] Failed to read secure storage: $e');
     }
@@ -48,22 +53,35 @@ class UserProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> setAuthToken(String token) async {
+    _authToken = token;
+    try {
+      await _secureStorage.write(key: _keyAuthToken, value: token);
+      debugPrint('✅ [UserProvider] Saved authToken: $_authToken');
+    } catch (e) {
+      debugPrint('❌ [UserProvider] Failed to save authToken: $e');
+    }
+    notifyListeners();
+  }
+
   /// Clears the stored username. The device token is kept so a trusted
   /// device can still bypass OTP on the next login. Pass `true` to
   /// [removeDeviceToken] to wipe the token as well.
   Future<void> clear({bool removeDeviceToken = false}) async {
     _username = '';
+    _authToken = '';
     if (removeDeviceToken) {
       _deviceToken = '';
     }
 
     try {
       await _secureStorage.delete(key: _keyUsername);
+      await _secureStorage.delete(key: _keyAuthToken);
       if (removeDeviceToken) {
         await _secureStorage.delete(key: _keyDeviceToken);
-        debugPrint('🧹 [UserProvider] Cleared username and deviceToken');
+        debugPrint('🧹 [UserProvider] Cleared username, authToken and deviceToken');
       } else {
-        debugPrint('🧹 [UserProvider] Cleared username');
+        debugPrint('🧹 [UserProvider] Cleared username and authToken');
       }
     } catch (e) {
       debugPrint('❌ [UserProvider] Failed to clear secure storage: $e');


### PR DESCRIPTION
## Summary
- store and manage auth tokens in `UserProvider`
- attach bearer token headers across `ApiService` requests
- save auth token after login and use it throughout the app

## Testing
- `dart format lib/providers/user_provider.dart lib/services/api_service.dart lib/features/auth/login_screen.dart lib/features/dashboard/tabs/home_tab.dart lib/features/profile/profile_screen.dart lib/features/dashboard/store_detail_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a81cd05e948324aa8ec131aba4bf0c