### PR TITLE
Add in-memory hourly cache refresh fallback

### DIFF
--- a/service/src/main/java/com/vivacrm/crm/controller/DashboardController.java
+++ b/service/src/main/java/com/vivacrm/crm/controller/DashboardController.java
@@ -1,6 +1,7 @@
 // src/main/java/com/vivacrm/crm/controller/DashboardController.java
 package com.vivacrm.crm.controller;
 
+import com.vivacrm.crm.schedule.CacheRefreshScheduler;
 import com.vivacrm.crm.service.DashboardService;
 import com.vivacrm.crm.service.dto.DashboardPayload;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -13,7 +14,13 @@ import java.time.LocalDateTime;
 public class DashboardController {
 
     private final DashboardService dashboardService;
-    public DashboardController(DashboardService dashboardService) { this.dashboardService = dashboardService; }
+    private final CacheRefreshScheduler refreshScheduler;
+
+    public DashboardController(DashboardService dashboardService,
+                               CacheRefreshScheduler refreshScheduler) {
+        this.dashboardService = dashboardService;
+        this.refreshScheduler = refreshScheduler;
+    }
 
     /** Returns cached metrics unless `refresh=true` is provided. */
     @GetMapping("/metrics")
@@ -21,6 +28,8 @@ public class DashboardController {
             @RequestParam(name = "refresh", defaultValue = "false") boolean refresh,
             @RequestParam(name = "forDate", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime forDate) {
+
+        refreshScheduler.refreshIfStale();
 
         if (forDate != null) {
             return dashboardService.getMetrics(forDate);

--- a/service/src/main/java/com/vivacrm/crm/controller/StoreController.java
+++ b/service/src/main/java/com/vivacrm/crm/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.vivacrm.crm.controller;
 
+import com.vivacrm.crm.schedule.CacheRefreshScheduler;
 import com.vivacrm.crm.service.StoreKpiService;
 import com.vivacrm.crm.service.dto.StoreKpi;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +16,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController {
 
     private final StoreKpiService kpiService;
+    private final CacheRefreshScheduler refreshScheduler;
 
-    public StoreController(StoreKpiService kpiService) {
+    public StoreController(StoreKpiService kpiService,
+                           CacheRefreshScheduler refreshScheduler) {
         this.kpiService = kpiService;
+        this.refreshScheduler = refreshScheduler;
     }
 
     @GetMapping("/{storeId}/kpi")
     public StoreKpi kpi(@PathVariable int storeId,
                         @RequestParam(name = "refresh", defaultValue = "false") boolean refresh) {
+        refreshScheduler.refreshIfStale();
         return refresh ? kpiService.refreshStoreKpi(storeId) : kpiService.getStoreKpi(storeId);
     }
 


### PR DESCRIPTION
## Summary
- Track last cache refresh time and provide `refreshIfStale` fallback when cron jobs don't run
- Use refresh fallback in dashboard and store endpoints to ensure data is refreshed hourly

## Testing
- `cd service && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68af84ff1660832484efe31e69a5c2b4