### PR TITLE
Align store KPI metrics with last completed hour cutoff

### DIFF
--- a/crm_retail_app/lib/providers/date_provider.dart
+++ b/crm_retail_app/lib/providers/date_provider.dart
@@ -2,15 +2,26 @@ import 'package:flutter/material.dart';
 
 /// Holds the currently selected date for dashboard calculations.
 class DateProvider extends ChangeNotifier {
-  DateTime _selectedDate = DateTime.now();
+  DateTime _selectedDate = _normalize(DateTime.now());
 
   DateTime get selectedDate => _selectedDate;
 
   /// Updates the selected date/time and notifies listeners if changed.
   void setDate(DateTime date) {
-    if (!_selectedDate.isAtSameMomentAs(date)) {
-      _selectedDate = date;
+    final normalized = _normalize(date);
+    if (!_selectedDate.isAtSameMomentAs(normalized)) {
+      _selectedDate = normalized;
       notifyListeners();
     }
+  }
+
+  /// Returns the start of the current hour for today's date
+  /// or midnight for historical dates.
+  static DateTime _normalize(DateTime date) {
+    final now = DateTime.now();
+    if (date.year == now.year && date.month == now.month && date.day == now.day) {
+      return DateTime(now.year, now.month, now.day, now.hour);
+    }
+    return DateTime(date.year, date.month, date.day);
   }
 }

--- a/service/src/main/java/com/vivacrm/crm/controller/StoreController.java
+++ b/service/src/main/java/com/vivacrm/crm/controller/StoreController.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/stores")
@@ -26,8 +29,14 @@ public class StoreController {
 
     @GetMapping("/{storeId}/kpi")
     public StoreKpi kpi(@PathVariable int storeId,
-                        @RequestParam(name = "refresh", defaultValue = "false") boolean refresh) {
+                        @RequestParam(name = "refresh", defaultValue = "false") boolean refresh,
+                        @RequestParam(name = "forDate", required = false)
+                        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime forDate) {
         refreshScheduler.refreshIfStale();
+
+        if (forDate != null) {
+            return kpiService.getStoreKpi(storeId, forDate);
+        }
         return refresh ? kpiService.refreshStoreKpi(storeId) : kpiService.getStoreKpi(storeId);
     }
 


### PR DESCRIPTION
## Summary
- Send `forDate` to store KPI endpoint and support historical queries
- Compute last completed hour cutoff so today's data matches dashboard metrics
- Normalize client date selection to current hour or full day for past dates

## Testing
- `./gradlew test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa626f758832480bed4d934f2cfef