### PR TITLE
Schedule hourly cache refresh at top of hour

### DIFF
--- a/service/src/main/java/com/vivacrm/crm/schedule/CacheRefreshScheduler.java
+++ b/service/src/main/java/com/vivacrm/crm/schedule/CacheRefreshScheduler.java
@@ -26,10 +26,10 @@ public class CacheRefreshScheduler {
     }
 
     /**
-     * Runs five minutes after the top of each hour (e.g. 10:05).
+     * Runs at the top of each hour (e.g. 10:00).
      * Zone can be omitted if you want server default.
      */
-    @Scheduled(cron = "${app.cache.refresh.cron:0 5 * * * *}", zone = "Europe/Belgrade")
+    @Scheduled(cron = "${app.cache.refresh.cron:0 0 * * * *}", zone = "Europe/Belgrade")
     public void scheduledRefresh() {
         refreshAll();
     }

--- a/service/src/main/java/com/vivacrm/crm/service/DashboardService.java
+++ b/service/src/main/java/com/vivacrm/crm/service/DashboardService.java
@@ -92,10 +92,10 @@ public class DashboardService {
     public void resetMetrics() { /* no-op */ }
 
     /**
-     * Auto-refresh today's metrics shortly after the top of every hour
-     * (e.g. 10:01, 11:01). Historical dates remain cached indefinitely.
+     * Auto-refresh today's metrics at the top of every hour
+     * (e.g. 10:00, 11:00). Historical dates remain cached indefinitely.
      */
-    @Scheduled(cron = "0 1 * * * *", zone = "Europe/Belgrade")
+    @Scheduled(cron = "0 0 * * * *", zone = "Europe/Belgrade")
     @Transactional(readOnly = true)
     public void refreshMetricsHourly() {
         refreshMetrics();


### PR DESCRIPTION
## Summary
- Refresh dashboard and store caches right at the top of each hour
- Align dashboard metric auto-refresh with top-of-hour schedule

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b0457697b483249476ff3132b01fe4