### PR TITLE
Align dashboard and store KPI SP parameters

### DIFF
--- a/service/src/main/java/com/vivacrm/crm/service/StoreKpiService.java
+++ b/service/src/main/java/com/vivacrm/crm/service/StoreKpiService.java
@@ -125,7 +125,8 @@ public class StoreKpiService {
     private List<Map<String, Object>> fetchRows(LocalDateTime dateTime) {
         LocalDateTime now = LocalDateTime.now();
         LocalDate today = now.toLocalDate();
-        LocalDateTime queryTime = dateTime != null ? dateTime : now;
+        LocalDateTime queryTime = (dateTime != null ? dateTime : now)
+                .withMinute(0).withSecond(0).withNano(0);
 
         if (dateTime == null || queryTime.toLocalDate().isEqual(today)) {
             Timestamp asOf = Timestamp.valueOf(queryTime);


### PR DESCRIPTION
## Summary
- Pass matching `ForDate` and `AsOf` values when invoking `SP_GetDashboardData` to sync with `SP_GetStoreKPI`
- Truncate query timestamps to the last whole hour before calling stored procedures

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b0498bb7488324a54f30a54bebb8d0