### PR TITLE
Handle nullable Store KPI fields

### DIFF
--- a/crm_retail_app/lib/models/dashboard_models.dart
+++ b/crm_retail_app/lib/models/dashboard_models.dart
@@ -88,10 +88,10 @@ class StoreKpiMetrics {
   final double avgBasketDiff;
   final int peakHour;
   final String peakHourLabel;
-  final double peakHourRevenue;
-  final String topArtCode;
-  final double topArtRevenue;
-  final String topArtName;
+  final double? peakHourRevenue;
+  final String? topArtCode;
+  final double? topArtRevenue;
+  final String? topArtName;
 
   StoreKpiMetrics({
     required this.storeId,
@@ -109,10 +109,10 @@ class StoreKpiMetrics {
     required this.avgBasketDiff,
     required this.peakHour,
     required this.peakHourLabel,
-    required this.peakHourRevenue,
-    required this.topArtCode,
-    required this.topArtRevenue,
-    required this.topArtName,
+    this.peakHourRevenue,
+    this.topArtCode,
+    this.topArtRevenue,
+    this.topArtName,
   });
 
   factory StoreKpiMetrics.fromJson(Map<String, dynamic> json) {
@@ -132,10 +132,10 @@ class StoreKpiMetrics {
       avgBasketDiff: (json['avgBasketDiff'] as num).toDouble(),
       peakHour: (json['peakHour'] as num).toInt(),
       peakHourLabel: json['peakHourLabel'] as String,
-      peakHourRevenue: (json['peakHourRevenue'] as num).toDouble(),
-      topArtCode: json['topArtCode'] as String,
-      topArtRevenue: (json['topArtRevenue'] as num).toDouble(),
-      topArtName: json['topArtName'] as String,
+      peakHourRevenue: (json['peakHourRevenue'] as num?)?.toDouble(),
+      topArtCode: json['topArtCode'] as String?,
+      topArtRevenue: (json['topArtRevenue'] as num?)?.toDouble(),
+      topArtName: json['topArtName'] as String?,
     );
   }
 }
@@ -175,10 +175,10 @@ class StoreKpiDetail {
   final double avgBasketDiff;
   final int peakHour;
   final String peakHourLabel;
-  final double peakHourRevenue;
-  final String topArtCode;
-  final double topArtRevenue;
-  final String topArtName;
+  final double? peakHourRevenue;
+  final String? topArtCode;
+  final double? topArtRevenue;
+  final String? topArtName;
 
   StoreKpiDetail({
     required this.storeId,
@@ -196,10 +196,10 @@ class StoreKpiDetail {
     required this.avgBasketDiff,
     required this.peakHour,
     required this.peakHourLabel,
-    required this.peakHourRevenue,
-    required this.topArtCode,
-    required this.topArtRevenue,
-    required this.topArtName,
+    this.peakHourRevenue,
+    this.topArtCode,
+    this.topArtRevenue,
+    this.topArtName,
   });
 
   factory StoreKpiDetail.fromJson(Map<String, dynamic> json) {
@@ -219,10 +219,10 @@ class StoreKpiDetail {
       avgBasketDiff: (json['avgBasketDiff'] as num).toDouble(),
       peakHour: json['peakHour'] as int,
       peakHourLabel: json['peakHourLabel'] as String,
-      peakHourRevenue: (json['peakHourRevenue'] as num).toDouble(),
-      topArtCode: json['topArtCode'] as String,
-      topArtRevenue: (json['topArtRevenue'] as num).toDouble(),
-      topArtName: json['topArtName'] as String,
+      peakHourRevenue: (json['peakHourRevenue'] as num?)?.toDouble(),
+      topArtCode: json['topArtCode'] as String?,
+      topArtRevenue: (json['topArtRevenue'] as num?)?.toDouble(),
+      topArtName: json['topArtName'] as String?,
     );
   }
 }

--- a/crm_retail_app/lib/services/api_service.dart
+++ b/crm_retail_app/lib/services/api_service.dart
@@ -192,7 +192,7 @@ class ApiService {
       _uriWithDate(ApiRoutes.storeKpi(storeId), date),
       headers: _authHeaders(),
     );
-    if (res.statusCode != 200) return null;
+    if (res.statusCode != 200 || res.body.isEmpty) return null;
     final data = jsonDecode(res.body) as Map<String, dynamic>;
     return StoreKpiDetail.fromJson(data);
   }
@@ -353,6 +353,9 @@ class ApiService {
       _uri(ApiRoutes.storeKpi(storeId)),
       headers: _authHeaders(),
     );
+    if (res.statusCode != 200 || res.body.isEmpty) {
+      throw Exception('Failed to load store KPI');
+    }
     final data = jsonDecode(res.body) as Map<String, dynamic>;
     return StoreKpiMetrics.fromJson(data);
   }


### PR DESCRIPTION
## Summary
- Allow nullable optional fields in Store KPI models
- Gracefully handle empty responses in Store KPI API calls

## Testing
- `dart --version` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b063480c408324bcca655042ac0477