### PR TITLE
feat: add dashboard refresh button

### DIFF
--- a/crm_retail_app/lib/features/dashboard/dashboard_screen.dart
+++ b/crm_retail_app/lib/features/dashboard/dashboard_screen.dart
@@ -16,11 +16,13 @@ class DashboardScreen extends StatefulWidget {
 class _DashboardScreenState extends State<DashboardScreen> {
   int _currentIndex = 0;
 
-  final List<Widget> _pages = [
-    HomeTab(),
-    SalesTab(),
-    InventoryTab(),
-    SettingsTab(),
+  final GlobalKey<HomeTabState> _homeTabKey = GlobalKey<HomeTabState>();
+
+  late final List<Widget> _pages = [
+    HomeTab(key: _homeTabKey),
+    const SalesTab(),
+    const InventoryTab(),
+    const SettingsTab(),
   ];
 
   final List<String> _titles = ['Stores', 'B2B/C', 'Stock', 'Settings'];
@@ -31,6 +33,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
       appBar: AppBar(
         title: Text(_titles[_currentIndex]),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              if (_currentIndex == 0) {
+                _homeTabKey.currentState?.refresh();
+              }
+            },
+          ),
           Consumer<DateProvider>(
             builder: (context, dateProvider, _) => IconButton(
               icon: const Icon(Icons.calendar_today),

--- a/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
@@ -571,10 +571,11 @@ class HomeTab extends StatefulWidget {
   const HomeTab({super.key});
 
   @override
-  State<HomeTab> createState() => _HomeTabState();
+  State<HomeTab> createState() => HomeTabState();
 }
 
-class _HomeTabState extends State<HomeTab> {
+/// Public state class so parents can trigger a manual refresh via [GlobalKey].
+class HomeTabState extends State<HomeTab> {
   late ApiService _api;
   late Future<DashboardData> _future;
 
@@ -619,6 +620,11 @@ class _HomeTabState extends State<HomeTab> {
 
   void _refreshData() {
     setState(_setFuture);
+  }
+
+  /// Triggers a fresh fetch of dashboard data using the current parameters.
+  void refresh() {
+    _refreshData();
   }
 
   String _formatDuration(Duration d) {


### PR DESCRIPTION
## Summary
- allow HomeTab state to be accessed so the parent can trigger a manual refresh
- add AppBar refresh button to reload dashboard metrics on demand

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b16127cd7c8324b943cc04cc5ae65a