### PR TITLE
Make cache refresh interval configurable

### DIFF
--- a/service/src/main/java/com/vivacrm/crm/schedule/CacheRefreshScheduler.java
+++ b/service/src/main/java/com/vivacrm/crm/schedule/CacheRefreshScheduler.java
@@ -65,8 +65,13 @@ public class CacheRefreshScheduler {
         }
     }
 
-    @Scheduled(cron = "0 5 * * * *")
+    @Scheduled(fixedRateString = "#{@cacheRefreshScheduler.refreshIntervalMillis}")
     public void scheduledRefresh() {
         refreshAll();
+    }
+
+    /** Expose refresh interval for SpEL used by @Scheduled. */
+    public long getRefreshIntervalMillis() {
+        return refreshInterval.toMillis();
     }
 }


### PR DESCRIPTION
## Summary
- Schedule cache refreshes using the configured `app.cache.refresh.interval`
- Expose helper to convert the interval for Spring's scheduler

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b1841cb4708324aff4fe6d725f05ca