### PR TITLE
Allow forcing dashboard refresh

### DIFF
--- a/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
+++ b/crm_retail_app/lib/features/dashboard/tabs/home_tab.dart
@@ -613,13 +613,13 @@ class HomeTabState extends State<HomeTab> {
     });
   }
 
-  void _setFuture() {
-    _future = _api.fetchDashboard(date: _currentDate);
+  void _setFuture({bool refresh = true}) {
+    _future = _api.fetchDashboard(date: _currentDate, refresh: refresh);
     _timeLeft = _calculateTimeLeft();
   }
 
   Future<void> _refreshData() async {
-    setState(_setFuture);
+    setState(() => _setFuture());
     await _future;
   }
 

--- a/crm_retail_app/lib/services/api_service.dart
+++ b/crm_retail_app/lib/services/api_service.dart
@@ -13,10 +13,20 @@ class ApiService {
   String? authToken;
 
   Uri _uri(String path) => Uri.parse('$baseUrl$path');
-  Uri _uriWithDate(String path, DateTime? date) {
-    if (date == null) return _uri(path);
-    final formatted = date.toIso8601String();
-    return Uri.parse('$baseUrl$path?forDate=$formatted');
+
+  /// Builds a [Uri] for [path] and optionally adds `forDate` and `refresh`
+  /// query parameters.
+  Uri _uriWithDate(String path, DateTime? date, {bool refresh = false}) {
+    final query = <String, String>{};
+    if (date != null) {
+      query['forDate'] = date.toIso8601String();
+    }
+    if (refresh) {
+      query['refresh'] = 'true';
+    }
+    return Uri.parse('$baseUrl$path').replace(
+      queryParameters: query.isEmpty ? null : query,
+    );
   }
 
   Map<String, String> _authHeaders([Map<String, String>? headers]) {
@@ -75,9 +85,9 @@ class ApiService {
     }
   }
 
-  Future<List<SummaryMetric>> fetchMetrics({DateTime? date}) async {
+  Future<List<SummaryMetric>> fetchMetrics({DateTime? date, bool refresh = false}) async {
     final res = await http.get(
-      _uriWithDate(ApiRoutes.metrics, date),
+      _uriWithDate(ApiRoutes.metrics, date, refresh: refresh),
       headers: _authHeaders(),
     );
     final data = jsonDecode(res.body) as Map<String, dynamic>;
@@ -107,9 +117,9 @@ class ApiService {
   /// Fetches dashboard data including metrics, sales series and store
   /// comparisons. The backend returns a `DashboardPayload` object which is
   /// mapped into strongly typed models for the UI layer.
-  Future<DashboardData> fetchDashboard({DateTime? date}) async {
+  Future<DashboardData> fetchDashboard({DateTime? date, bool refresh = false}) async {
     final res = await http.get(
-      _uriWithDate(ApiRoutes.metrics, date),
+      _uriWithDate(ApiRoutes.metrics, date, refresh: refresh),
       headers: _authHeaders(),
     );
     final data = jsonDecode(res.body) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary
- let ApiService append refresh=true to dashboard calls
- refresh home tab data by default using new API param

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1841cb4708324aff4fe6d725f05ca