### PR TITLE
Ensure hourly data refresh for UI and backend

### DIFF
--- a/crm_retail_app/lib/providers/date_provider.dart
+++ b/crm_retail_app/lib/providers/date_provider.dart
@@ -1,8 +1,14 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 
 /// Holds the currently selected date for dashboard calculations.
 class DateProvider extends ChangeNotifier {
   DateTime _selectedDate = _normalize(DateTime.now());
+  Timer? _timer;
+
+  DateProvider() {
+    _scheduleNextTick();
+  }
 
   DateTime get selectedDate => _selectedDate;
 
@@ -13,6 +19,23 @@ class DateProvider extends ChangeNotifier {
       _selectedDate = normalized;
       notifyListeners();
     }
+  }
+
+  void _scheduleNextTick() {
+    _timer?.cancel();
+    final now = DateTime.now();
+    final next = DateTime(now.year, now.month, now.day, now.hour + 1);
+    final duration = next.difference(now);
+    _timer = Timer(duration, () {
+      setDate(DateTime.now());
+      _scheduleNextTick();
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
   }
 
   /// Returns the start of the current hour for today's date

--- a/service/src/main/java/com/vivacrm/crm/schedule/CacheRefreshScheduler.java
+++ b/service/src/main/java/com/vivacrm/crm/schedule/CacheRefreshScheduler.java
@@ -65,13 +65,8 @@ public class CacheRefreshScheduler {
         }
     }
 
-    @Scheduled(fixedRateString = "#{@cacheRefreshScheduler.refreshIntervalMillis}")
+    @Scheduled(cron = "${app.cache.refresh.cron:0 0 * * * *}", zone = "${app.timezone:UTC}")
     public void scheduledRefresh() {
         refreshAll();
-    }
-
-    /** Expose refresh interval for SpEL used by @Scheduled. */
-    public long getRefreshIntervalMillis() {
-        return refreshInterval.toMillis();
     }
 }


### PR DESCRIPTION
## Summary
- auto-update dashboard date on the hour in Flutter provider
- run cache refresh on top of every hour via cron in backend

## Testing
- `dart format lib/providers/date_provider.dart` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package)*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b18661ec488324a7be3b1f5e4a604c